### PR TITLE
Problem: Transaction not re-usable in core msg

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -49,8 +48,7 @@ const (
 
 // Transaction is an Ethereum transaction.
 type Transaction struct {
-	inner TxData    // Consensus contents of a transaction
-	time  time.Time // Time first seen locally (spam avoidance)
+	inner TxData // Consensus contents of a transaction
 
 	// caches
 	hash atomic.Value
@@ -200,7 +198,6 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 // setDecoded sets the inner transaction and size after decoding.
 func (tx *Transaction) setDecoded(inner TxData, size uint64) {
 	tx.inner = inner
-	tx.time = time.Now()
 	if size > 0 {
 		tx.size.Store(size)
 	}
@@ -406,7 +403,7 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 	}
 	cpy := tx.inner.copy()
 	cpy.setSignatureValues(signer.ChainID(), v, r, s)
-	return &Transaction{inner: cpy, time: tx.time}, nil
+	return &Transaction{inner: cpy}, nil
 }
 
 // Transactions implements DerivableList for transactions.
@@ -501,9 +498,6 @@ func (s TxByPriceAndTime) Less(i, j int) bool {
 	// If the prices are equal, use the time the transaction was first seen for
 	// deterministic sorting
 	cmp := s[i].minerFee.Cmp(s[j].minerFee)
-	if cmp == 0 {
-		return s[i].tx.time.Before(s[j].tx.time)
-	}
 	return cmp > 0
 }
 func (s TxByPriceAndTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -26,7 +26,6 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -360,6 +359,8 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 // Tests that if multiple transactions have the same price, the ones seen earlier
 // are prioritized to avoid network spam attacks aiming for a specific ordering.
 func TestTransactionTimeSort(t *testing.T) {
+	t.Skip("time field is removed")
+
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 5)
 	for i := 0; i < len(keys); i++ {
@@ -369,11 +370,10 @@ func TestTransactionTimeSort(t *testing.T) {
 
 	// Generate a batch of transactions with overlapping prices, but different creation times
 	groups := map[common.Address]Transactions{}
-	for start, key := range keys {
+	for _, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 
 		tx, _ := SignTx(NewTransaction(0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
-		tx.time = time.Unix(0, int64(len(keys)-start))
 
 		groups[addr] = append(groups[addr], tx)
 	}
@@ -398,8 +398,8 @@ func TestTransactionTimeSort(t *testing.T) {
 				t.Errorf("invalid gasprice ordering: tx #%d (A=%x P=%v) < tx #%d (A=%x P=%v)", i, fromi[:4], txi.GasPrice(), i+1, fromNext[:4], next.GasPrice())
 			}
 			// Make sure time order is ascending if the txs have the same gas price
-			if txi.GasPrice().Cmp(next.GasPrice()) == 0 && txi.time.After(next.time) {
-				t.Errorf("invalid received time ordering: tx #%d (A=%x T=%v) > tx #%d (A=%x T=%v)", i, fromi[:4], txi.time, i+1, fromNext[:4], next.time)
+			if txi.GasPrice().Cmp(next.GasPrice()) == 0 {
+				t.Errorf("invalid received time ordering: tx #%d (A=%x) > tx #%d (A=%x)", i, fromi[:4], i+1, fromNext[:4])
 			}
 		}
 	}


### PR DESCRIPTION
We try to reuse the Transaction type in external system(ethermint/cronos), the time field is a roadblock that breaks the deep equality checking in unit tests.
The time field is not used in ethermint/cronos anyway, so we can simply remove it.

see: https://github.com/crypto-org-chain/ethermint/pull/478